### PR TITLE
Gather all chunks of POST body before splitting

### DIFF
--- a/collectd-graphite-proxy.js
+++ b/collectd-graphite-proxy.js
@@ -58,8 +58,17 @@ graphite_connection.on("error", function() {
 
 var request_handler = function(request, response) {
   var putval_re = /^PUTVAL ([^ ]+)(?: ([^ ]+=[^ ]+)?) ([0-9.]+)(:.*)/;
+  var chunks = [];
   request.addListener("data", function(chunk) {
-    metrics = chunk.toString().split("\n");
+    chunks.push(chunk.toString());
+  });
+  request.addListener("end", function(chunk) {
+    var body = chunks.join("");
+    if (parseInt(request.headers["content-length"]) != body.length) {
+      console.log("Content-Length: %d != body.length: %d\n",
+        request.headers["content-length"], body.length);
+    }
+    var metrics = body.split("\n");
     for (var i in metrics) {
       var m = putval_re.exec(metrics[i]);
       if (!m) {


### PR DESCRIPTION
The boundary between chunks is not guaranteed to fall at the end of a PUTVAL line.

The worst possible place this boundary can fall is in the value.  In this case, the truncated line will pass putval_re and be loaded into Graphite with an incorrect value.
